### PR TITLE
Changes for RPMFusion (Nouveau Full Activated)

### DIFF
--- a/BlacklistNvidia.sh
+++ b/BlacklistNvidia.sh
@@ -45,7 +45,7 @@ if [[ `sudo cat /etc/grub.d/40_custom | grep rd.driver.blacklist=nouveau` == '' 
     sudo sed -i '/vmlinuz/s/$/ rd.driver.blacklist=nouveau/' /etc/grub.d/40_custom
 fi
 if [[ `sudo cat /etc/grub.d/40_custom | grep modprobe.blacklist=nouveau` == '' ]]; then
-    sudo sed -i '/vmlinuz/s/$/ modprobe.blacklist=nouveau' /etc/grub.d/40_custom
+    sudo sed -i '/vmlinuz/s/$/ modprobe.blacklist=nouveau/' /etc/grub.d/40_custom
 fi
 if [[ `sudo cat /etc/grub.d/40_custom | grep nvidia-drm.modeset=1` == '' ]]; then
     sudo sed -i '/vmlinuz/s/$/ nvidia-drm.modeset=1/' /etc/grub.d/40_custom

--- a/BlacklistNvidia.sh
+++ b/BlacklistNvidia.sh
@@ -26,6 +26,7 @@ fi
 
 # Enables nouveau by default
 sudo sed -i 's/\<rd.driver.blacklist=nouveau\> //g' /etc/default/grub
+sudo sed -i 's/\<modprobe.blacklist=nouveau\> //g' /etc/default/grub
 sudo sed -i 's/\<nvidia-drm.modeset=1\> //g' /etc/default/grub
 
 sudo cat /etc/default/grub
@@ -42,6 +43,9 @@ exec tail -n +3 \$0
 
 if [[ `sudo cat /etc/grub.d/40_custom | grep rd.driver.blacklist=nouveau` == '' ]]; then
     sudo sed -i '/vmlinuz/s/$/ rd.driver.blacklist=nouveau/' /etc/grub.d/40_custom
+fi
+if [[ `sudo cat /etc/grub.d/40_custom | grep modprobe.blacklist=nouveau` == '' ]]; then
+    sudo sed -i '/vmlinuz/s/$/ modprobe.blacklist=nouveau' /etc/grub.d/40_custom
 fi
 if [[ `sudo cat /etc/grub.d/40_custom | grep nvidia-drm.modeset=1` == '' ]]; then
     sudo sed -i '/vmlinuz/s/$/ nvidia-drm.modeset=1/' /etc/grub.d/40_custom


### PR DESCRIPTION
RPMFusion has the following command to blacklist nouveau: rd.driver.blacklist=nouveau modprobe.blacklist=nouveau
With these changes it is possible to use Gnome's right click menu.

![image](https://user-images.githubusercontent.com/10439087/36600891-5a5142c8-1892-11e8-94f7-2248da1bc7e8.png)
